### PR TITLE
Adds ifEmpty() and ifNotEmpty() methods

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -3721,4 +3721,40 @@ class Map implements \ArrayAccess, \Countable, \IteratorAggregate
 			}
 		}
 	}
+
+	/**
+	 * Executes $callback if the Map is empty
+	 *
+	 * Examples:
+	 *  $page = $pages
+	 *      ->filter(fn(Page $page, $_) => $page->GetIdentifier() == $pageParameters->Page)
+	 *      ->ifEmpty(fn ($_) => die("unknown page: $pageParameters->Page"))
+	 *      ->first();
+	 *
+	 * @param  callable $callback Function with (Map) parameter and returns void
+	 * @return self Same map for fluid interface
+	 */
+	public function ifEmpty( callable $callback ) : self
+	{
+		if( empty($this->list) ) {
+			$callback($this);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Executes $callback if the Map is not empty
+	 *
+	 * @param  callable $callback Function with (Map) parameter and returns void
+	 * @return self Same map for fluid interface
+	 */
+	public function ifNotEmpty( callable $callback ) : self
+	{
+		if( !empty($this->list) ) {
+			$callback($this);
+		}
+
+		return $this;
+	}
 }


### PR DESCRIPTION
This is a proposal to add some common conditional execution methods (or a generic `if($condition, $callback)`). The pull request itself adds ifEmpty(..) and ifNotEmpty(..) mostly to show what I had in mind. I wanted to set up this pull request to ask if this is something desirable before going in and adding a bunch.

Here's the situation this solves in my code:
```

$pages = new Map(array(
    FilterPage::Create(),
    WalletsPage::Create(),
    WalletPage::Create(),
    CategoryPage::Create(),
    TagPage::Create(),
    StorePage::Create(),
));

$page = $pages
    ->filter(fn(Page $page, $_) => $page->GetIdentifier() == $pageParameters->Page)
    ->ifEmpty(fn ($_) => die("unknown page: $pageParameters->Page"))
    ->first();
CastToPage($page)
    ->SetDictionary($dictionary)
    ->SetConfig($config)
    ->SetPageParameters($pageParameters)
    ->SetTransactionSelections($account)
    ->Process()
    ->Render();
```
(the `CastToPage(..)` is still a problem I'm trying to solve, ignore that)