### PR TITLE
mapKeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .phpunit.result.cache
 coveralls.json
 composer.lock

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ will return:
 * [groupBy()](#groupby) : Groups associative array elements or objects
 * [join()](#join) : Returns concatenated elements as string with separator
 * [map()](#map) : Applies a callback to each element and returns the results
+* [mapKeys()](#mapKeys) : Applies a callback to each key and returns the results
 * [partition()](#partition) : Breaks the list into the given number of groups
 * [pipe()](#pipe) : Applies a callback to the whole map
 * [prefix()](#prefix) : Adds a prefix to each map entry
@@ -2197,6 +2198,27 @@ Map::from( ['a' => 2, 'b' => 4] )->map( function( $value, $key ) {
     return $value * 2;
 } );
 // ['a' => 4, 'b' => 8]
+```
+
+
+### mapKeys()
+
+Calls the passed function once for each key and returns a new map for the result.
+
+```php
+public function mapKeys( callable $callback ) : self
+```
+
+* @param callable `$callback` Function with (value, key) parameters and returns computed result
+* @return self New map with the computed keys and the original values
+
+**Examples:**
+
+```php
+Map::from( ['a' => 2, 'b' => 4] )->mapKeys( function( $value, $key ) {
+    return $key . 'A';
+} );
+// ['aA' => 2, 'bA' => 4]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -353,11 +353,11 @@ will return:
 * [groupBy()](#groupby) : Groups associative array elements or objects
 * [join()](#join) : Returns concatenated elements as string with separator
 * [map()](#map) : Applies a callback to each element and returns the results
-* [mapKeys()](#mapKeys) : Applies a callback to each key and returns the results
 * [partition()](#partition) : Breaks the list into the given number of groups
 * [pipe()](#pipe) : Applies a callback to the whole map
 * [prefix()](#prefix) : Adds a prefix to each map entry
 * [reduce()](#reduce) : Computes a single value from the map content
+* [rekey()](#rekey) : Applies a callback to each key and returns the results
 * [replace()](#replace) : Replaces elements recursively
 * [splice()](#splice) : Replaces a slice by new elements
 * [suffix()](#suffix) : Adds a suffix to each map entry
@@ -2201,27 +2201,6 @@ Map::from( ['a' => 2, 'b' => 4] )->map( function( $value, $key ) {
 ```
 
 
-### mapKeys()
-
-Calls the passed function once for each key and returns a new map for the result.
-
-```php
-public function mapKeys( callable $callback ) : self
-```
-
-* @param callable `$callback` Function with (value, key) parameters and returns computed result
-* @return self New map with the computed keys and the original values
-
-**Examples:**
-
-```php
-Map::from( ['a' => 2, 'b' => 4] )->mapKeys( function( $value, $key ) {
-    return $key . 'A';
-} );
-// ['aA' => 2, 'bA' => 4]
-```
-
-
 ### max()
 
 Returns the maximum value of all elements.
@@ -2810,6 +2789,27 @@ Map::from( [2 => 'a', 13 => 'm', 30 => 'z'] )->reject( 'm' );
 
 Map::from( [2 => 'a', 6 => null, 13 => 'm'] )->reject();
 // [6 => null]
+```
+
+
+### rekey()
+
+Calls the passed function once for each key and returns a new map for the result.
+
+```php
+public function rekey( callable $callback ) : self
+```
+
+* @param callable `$callback` Function with (value, key) parameters and returns computed result
+* @return self New map with the computed keys and the original values
+
+**Examples:**
+
+```php
+Map::from( ['a' => 2, 'b' => 4] )->rekey( function( $value, $key ) {
+    return $key . 'A';
+} );
+// ['aA' => 2, 'bA' => 4]
 ```
 
 

--- a/src/Map.php
+++ b/src/Map.php
@@ -1844,7 +1844,7 @@ class Map implements \ArrayAccess, \Countable, \IteratorAggregate
 	 * @param callable $callback Function with (value, key) parameters and returns computed result
 	 * @return self New map with computed keys and original values
 	 */
-	public function mapKeys( callable $callback )
+	public function mapKeys( callable $callback ): self
 	{
 		$keys = array_keys( $this->list );
 		$newKeys = array_map( $callback, $this->list, $keys );

--- a/src/Map.php
+++ b/src/Map.php
@@ -1844,7 +1844,7 @@ class Map implements \ArrayAccess, \Countable, \IteratorAggregate
 	 * @param callable $callback Function with (value, key) parameters and returns computed result
 	 * @return self New map with computed keys and original values
 	 */
-	public function mapKeys( callable $callback ): self
+	public function mapKeys( callable $callback ) : self
 	{
 		$keys = array_keys( $this->list );
 		$newKeys = array_map( $callback, $this->list, $keys );

--- a/src/Map.php
+++ b/src/Map.php
@@ -1831,29 +1831,6 @@ class Map implements \ArrayAccess, \Countable, \IteratorAggregate
 
 
 	/**
-	 * Calls the passed function once for each key and returns a new map for the result.
-	 *
-	 * Examples:
-	 *  Map::from( ['a' => 2, 'b' => 4] )->mapKeys( function( $value, $key ) {
-	 *      return $key . "A";
-	 *  } );
-	 *
-	 * Results:
-	 *  ['aA' => 2, 'bA' => 4]
-	 *
-	 * @param callable $callback Function with (value, key) parameters and returns computed result
-	 * @return self New map with computed keys and original values
-	 */
-	public function mapKeys( callable $callback ) : self
-	{
-		$keys = array_keys( $this->list );
-		$newKeys = array_map( $callback, $this->list, $keys );
-
-	return new static( array_combine( $newKeys, $this->list ) ?: [] );
-	}
-
-
-	/**
 	 * Returns the maximum value of all elements.
 	 *
 	 * Examples:
@@ -2457,6 +2434,29 @@ class Map implements \ArrayAccess, \Countable, \IteratorAggregate
 		return new static( array_filter( $this->list, function( $value, $key ) use  ( $callback, $isCallable ) {
 			return $isCallable ? !$callback( $value, $key ) : $value != $callback;
 		}, ARRAY_FILTER_USE_BOTH ) );
+	}
+
+
+	/**
+	 * Calls the passed function once for each key and returns a new map for the result.
+	 *
+	 * Examples:
+	 *  Map::from( ['a' => 2, 'b' => 4] )->rekey( function( $value, $key ) {
+	 *      return $key . "A";
+	 *  } );
+	 *
+	 * Results:
+	 *  ['aA' => 2, 'bA' => 4]
+	 *
+	 * @param callable $callback Function with (value, key) parameters and returns computed result
+	 * @return self New map with computed keys and original values
+	 */
+	public function rekey( callable $callback ) : self
+	{
+		$keys = array_keys( $this->list );
+		$newKeys = array_map( $callback, $this->list, $keys );
+
+		return new static( array_combine( $newKeys, $this->list ) ?: [] );
 	}
 
 

--- a/src/Map.php
+++ b/src/Map.php
@@ -1831,6 +1831,29 @@ class Map implements \ArrayAccess, \Countable, \IteratorAggregate
 
 
 	/**
+	 * Calls the passed function once for each key and returns a new map for the result.
+	 *
+	 * Examples:
+	 *  Map::from( ['a' => 2, 'b' => 4] )->mapKeys( function( $value, $key ) {
+	 *      return $key . "A";
+	 *  } );
+	 *
+	 * Results:
+	 *  ['aA' => 2, 'bA' => 4]
+	 *
+	 * @param callable $callback Function with (value, key) parameters and returns computed result
+	 * @return self New map with computed keys and original values
+	 */
+	public function mapKeys( callable $callback )
+	{
+		$keys = array_keys( $this->list );
+		$newKeys = array_map( $callback, $this->list, $keys );
+
+	return new static( array_combine( $newKeys, $this->list ) ?: [] );
+	}
+
+
+	/**
 	 * Returns the maximum value of all elements.
 	 *
 	 * Examples:

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -1376,7 +1376,7 @@ Array
 		} );
 
 		$this->assertInstanceOf( Map::class, $m );
-		$this->assertEquals( ['a1' => '1', 'b2' => 'b'], $m->toArray() );
+		$this->assertEquals( ['a-1' => '1', 'b-2' => 'b'], $m->toArray() );
 	}
 
 

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -1376,7 +1376,7 @@ Array
 		} );
 
 		$this->assertInstanceOf( Map::class, $m );
-		$this->assertEquals( ['a-1' => '1', 'b-2' => 'b'], $m->toArray() );
+		$this->assertEquals( ['a-1' => '1', 'b-2' => '2'], $m->toArray() );
 	}
 
 

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -1368,6 +1368,18 @@ Array
 	}
 
 
+	public function testMapKeys()
+	{
+		$m = new Map( ['a' => '1', 'b' => '2'] );
+		$m = $m->map( function( $item, $key ) {
+			return $key . '-' . $item;
+		} );
+
+		$this->assertInstanceOf( Map::class, $m );
+		$this->assertEquals( ['a1' => '1', 'b2' => 'b'], $m->toArray() );
+	}
+
+
 	public function testMax()
 	{
 		$this->assertEquals( 5, Map::from( [1, 3, 2, 5, 4] )->max() );

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -1371,7 +1371,7 @@ Array
 	public function testMapKeys()
 	{
 		$m = new Map( ['a' => '1', 'b' => '2'] );
-		$m = $m->map( function( $item, $key ) {
+		$m = $m->mapKeys( function( $item, $key ) {
 			return $key . '-' . $item;
 		} );
 

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -1368,18 +1368,6 @@ Array
 	}
 
 
-	public function testRekey()
-	{
-		$m = new Map( ['a' => '1', 'b' => '2'] );
-		$m = $m->rekey( function( $item, $key ) {
-			return $key . '-' . $item;
-		} );
-
-		$this->assertInstanceOf( Map::class, $m );
-		$this->assertEquals( ['a-1' => '1', 'b-2' => '2'], $m->toArray() );
-	}
-
-
 	public function testMax()
 	{
 		$this->assertEquals( 5, Map::from( [1, 3, 2, 5, 4] )->max() );
@@ -1778,6 +1766,18 @@ Array
 		$m = new Map( [2 => 'a', 6 => null, 13 => 'm'] );
 
 		$this->assertEquals( [6 => null], $m->reject()->toArray() );
+	}
+
+
+	public function testRekey()
+	{
+		$m = new Map( ['a' => '1', 'b' => '2'] );
+		$m = $m->rekey( function( $item, $key ) {
+			return $key . '-' . $item;
+		} );
+
+		$this->assertInstanceOf( Map::class, $m );
+		$this->assertEquals( ['a-1' => '1', 'b-2' => '2'], $m->toArray() );
 	}
 
 

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -1368,10 +1368,10 @@ Array
 	}
 
 
-	public function testMapKeys()
+	public function testRekey()
 	{
 		$m = new Map( ['a' => '1', 'b' => '2'] );
-		$m = $m->mapKeys( function( $item, $key ) {
+		$m = $m->rekey( function( $item, $key ) {
 			return $key . '-' . $item;
 		} );
 


### PR DESCRIPTION
Adds the companion function to map(..): mapKeys(..) intended for the purpose of rekeying the Map.

This is the specific use case this solves for me:

Old code:
```php
    private function LoadCategoriesFromDatabase(): array
    {
        $categoryDbInterface = CategoryDbInterface::Create($this->Database);
        $categoryTableRows = $categoryDbInterface->SelectAll();

        $categoryDatums = array();
        foreach ($categoryTableRows as $i => $categoryTableRow) {
            $categoryDatums[$categoryTableRow->Id] = CategoryDatum::FromCategoryTableRow($categoryTableRow);
        }

        return $categoryDatums;
    }
```

New code:
```php
    private function LoadCategoriesFromDatabase(): MapOfCategoryDatum
    {
        $categoryDbInterface = CategoryDbInterface::Create($this->Database);
        $categoryTableRows = $categoryDbInterface->SelectAll();

        $categoryDatums = $categoryTableRows
            ->map(fn(CategoryTableRow $categoryTableRow) => CategoryDatum::FromCategoryTableRow($categoryTableRow))
            ->CastToMapOfCategoryDatum()
            ->mapKeys(fn(CategoryDatum $categorydatum) => $categorydatum->Id);

        return $categoryDatums;
    }
```

The issue being that the array returned by `$categoryDbInterface->SelectAll();` isn't keyed by the category Id, so instead while `map(..)` handles the conversion of `CategoryTableRow` objects into `CategoryDatum` objects, keying remains as meaningless as what `$categoryDbInterface->SelectAll();` returned. The new `mapKeys(..)` function addresses this by rekeying all entries to be category Ids, which is what functions that call `LoadCategoriesFromDatabase()` expect.

Please let me know if this is something desired in this library. As before I'm only sharing functions I found useful or necessary. If there's an alternate way to achieve this I haven't found it, so making a more obvious way to achieve this might be a good idea irrespective of whether this pull request ends up being accepted or not.

Please ignore the `CastToMapOfCategoryDatum()`, it's there for type hinting

Thanks