### PR TITLE
makes return of if(..) consistent between $then==null and $else==null

### DIFF
--- a/src/Map.php
+++ b/src/Map.php
@@ -1514,7 +1514,7 @@ class Map implements \ArrayAccess, \Countable, \IteratorAggregate
 		} elseif( $else ) {
 			$result = $else( $this );
 		} else {
-			$result = [];
+			$result = $this;
 		}
 
 		return new self( $result );

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -1263,6 +1263,15 @@ Array
 	}
 
 
+	public function testIfThenReturn()
+	{
+		$r = Map::from( ['a'] )->if( true, function($_) {return ["b"];} );
+
+		$this->assertInstanceOf( Map::class, $r );
+		$this->assertEquals( ['b'], $r->all() );
+	}
+
+
 	public function testIfElse()
 	{
 		$r = Map::from( ['a'] )->if(
@@ -1273,6 +1282,15 @@ Array
 
 		$this->assertInstanceOf( Map::class, $r );
 		$this->assertEquals( [], $r->all() );
+	}
+
+
+	public function testIfElseReturn()
+	{
+		$r = Map::from( ['a'] )->if( false, null, function($_) {return ["b"];} );
+
+		$this->assertInstanceOf( Map::class, $r );
+		$this->assertEquals( ['b'], $r->all() );
 	}
 
 
@@ -1290,7 +1308,7 @@ Array
 		$r = Map::from( ['a'] )->if( false );
 
 		$this->assertInstanceOf( Map::class, $r );
-		$this->assertEquals( [], $r->all() );
+		$this->assertEquals( ['a'], $r->all() );
 	}
 
 


### PR DESCRIPTION
Corrects what's likely a typo: 
Currently if `$condition` is true, `if(..)` will return what `$then(..)` returns or `$this` if no `$then` is provided
however if `$condition` is false, `if(..)` will return what `$else(..)` returns or `[]` if no `$else` is provided.

For consistency it makes sense to me that a blank `$else` would behave the same as a blank `$then`, both returning `$this`.

(Noticed this as it caused a bug in my code:

```php
    public function Render(Dictionary &$dictionary): self
    {
        $this->pages
            ->filter(fn(Page $page, $_) => $page->GetIdentifier() == $this->pageParameters->Page)
            ->CastToMapOfPage()
            ->if(
                fn(MapOfPage &$Map) => $Map->isEmpty(),
                fn(&$_) => die("unknown page: " . $this->pageParameters->Page))
            ->first()   // <-- on success this will return null, as the $else in the call immediately above is blank
            ->SetDictionary($dictionary)
            ->SetConfig($this->config)
            ->SetPageParameters($this->pageParameters)
            ->SetTransactionSelections($this->account)
            ->Process()
            ->Render();

        return $this;
    }
```